### PR TITLE
Pin version of networkx

### DIFF
--- a/identity-resolution/notebooks/identity-graph/identity-graph-sample.ipynb
+++ b/identity-resolution/notebooks/identity-graph/identity-graph-sample.ipynb
@@ -126,7 +126,8 @@
    "source": [
     "%%bash\n",
     "\n",
-    "pip install colorlover tqdm intervaltree"
+    "pip install colorlover tqdm intervaltree\n",
+    "pip install --upgrade networkx==2.0"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:* 2

*Description of changes:*
 - Pin version of Networkx to 2.0 due to incompatibility. Functionality in question was deprecated in Networkx==2.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
