### PR TITLE
[Issue 4] Fixed Neptune cluster IAM role assignment for bulk load in primary te…

### DIFF
--- a/identity-resolution/templates/identity-resolution.yml
+++ b/identity-resolution/templates/identity-resolution.yml
@@ -5,7 +5,7 @@ Mappings:
     us-west-2:
       bucket: aws-admartech-samples-us-west-2
     us-east-1:
-      bucket: aws-admartech-samples
+      bucket: aws-admartech-samples-us-east-1
     us-east-2:
       bucket: aws-admartech-samples-us-east-2
     eu-west-1:
@@ -13,7 +13,7 @@ Mappings:
 
   Constants:
     S3Keys:
-      neptuneNotebooks: /identity-resolution/notebooks|identity-resolution/*
+      neptuneNotebooks: /identity-resolution/notebooks|identity-graph/*
       irdata: /identity-resolution/data/
       bulkLoadStack: /identity-resolution/templates/bulk-load-stack.yaml
 
@@ -78,22 +78,6 @@ Resources:
                                               - Constants
                                               - S3Keys
                                               - neptuneNotebooks
-      TimeoutInMinutes: '60'
-
-# ---------- CONNECTING IAM ROLE TO NEPTUNE CLUSTER ----------
-  AddIamRoleToNeptuneStack:
-    Type: AWS::CloudFormation::Stack
-    Properties:
-      TemplateURL: https://s3.amazonaws.com/aws-neptune-customer-samples/neptune-sagemaker/cloudformation-templates/common/add-iam-role-to-neptune.json
-      Parameters:
-        DBClusterId:
-          Fn::GetAtt:
-          - NeptuneBaseStack
-          - Outputs.DBClusterId
-        NeptuneLoadFromS3IAMRoleArn:
-          Fn::GetAtt:
-          - NeptuneBaseStack
-          - Outputs.NeptuneLoadFromS3IAMRoleArn
       TimeoutInMinutes: '60'
 
 # --------- LOAD DATA INTO NEPTUNE ---------


### PR DESCRIPTION
…mplate. Issue 4.

*Issue #, if available:*

Issue 4

*Description of changes:*

Removed reference to the AddIAMRoleToCluster substack as that is no longer needed to add the appropriate role to the Neptune cluster.  Adding the bulk load IAM role to the cluster is now accomplished through the Neptune Base Stack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
